### PR TITLE
Use format strings instead of old-style strings

### DIFF
--- a/fnsort.py
+++ b/fnsort.py
@@ -67,7 +67,7 @@ def sort_footnotes(text):
 
     # Make a list of the footnote-references in order of appearance the original footnotes in text.
     # this is not the order of the footnote contents, but the order of the footnote references in the text.
-    newlabels = ["[^%s]: %s" % (i + 1, labels[j]) for (i, j) in enumerate(order)]
+    newlabels = [f"[^{i+1}]: {labels[j]}" for (i, j) in enumerate(order)]
     # print(f"newlabels: {newlabels}")
 
     # Remove the old footnote-references and put the new ones at the end of the text.

--- a/fnsort.py
+++ b/fnsort.py
@@ -45,7 +45,7 @@ label = re.compile(r"^\[\^([^\]]+)\]:\s*((?:(?!\n\[)[\s\S])*)", re.MULTILINE)
 def refrepl(m, order):
     # Rewrite reference links with the reordered link numbers. Insert the first
     # character from the footnote reference link right before the new link.
-    return "%s[^%s]" % (m.group(0)[:1], order.index(m.group(2)) + 1)
+    return f"{m.group(0)[:1]}[^{order.index(m.group(2)) + 1}]"
 
 
 def sort_footnotes(text):


### PR DESCRIPTION
Modification to use format strings (f-strings) instead of old-style strings

Ultimately we trade extra parentheses and percent symbols for a few curly braces