### PR TITLE
Modify CI/CD trigger conditions for the docker job

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -5,12 +5,11 @@ on:
     # commented to avoid a potential triple run of the "test" job
     #  instead runs twice (pull_request and merge closed)
     # branches: ["main"]
-    tags:
-      - "v*"
+    tags: ["v*"]
   pull_request:
-    branches: [main]
+    branches: ["main"]
   pull_request_target:
-    types: [closed]
+    types: ["closed"]
 
 jobs:
   test:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,15 +1,21 @@
-name: Test, Build and Push Docker Image
+name: Test, Build, and Push Docker Image
 
 on:
   push:
-    # commented to avoid a potential triple run of the "test" job
-    #  instead runs twice (pull_request and merge closed)
-    # branches: ["main"]
-    tags: ["v*"]
+    branches: ["main"]
+    tags:
+      - "v*"
   pull_request:
     branches: ["main"]
-  pull_request_target:
-    types: ["closed"]
+  release:
+    types: ["created"]
+
+# GOAL:
+#  - run test job on pushes to main branch or v* tag
+#  - run test job on PRs against main branch
+#  - run test job on Release creation
+#  - run docker job on the above events when the triggered actor is the repo owner
+#  - run docker job on Release creation (ex: maybe a maintainer that isn't repo owner)
 
 jobs:
   test:
@@ -37,7 +43,11 @@ jobs:
       packages: write
     needs:
       - "test"
-    if: github.event.pull_request.merged == true
+    if: >-
+      ${{
+      github.triggering_actor == github.repository_owner ||
+      github.event_name == 'release' && github.event.action == 'created'
+      }}
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,11 +1,16 @@
 name: Test, Build and Push Docker Image
 
-"on":
+on:
   push:
-    branches: ["main"]
+    # commented to avoid a potential triple run of the "test" job
+    #  instead runs twice (pull_request and merge closed)
+    # branches: ["main"]
     tags:
       - "v*"
   pull_request:
+    branches: [main]
+  pull_request_target:
+    types: [closed]
 
 jobs:
   test:
@@ -33,6 +38,7 @@ jobs:
       packages: write
     needs:
       - "test"
+    if: github.event.pull_request.merged == true
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
resolves #11 
bug fix

**Why?**
On PR, the docker job runs but contributors (understandably) don't have access to the owner's secrets so the job fails.
The docker job shouldn't run unless the repo owner is the one triggering it.

**What?**
:dart: These GitHub Actions workflow modifications are to skip the docker job under _most_ circumstances (unless you're the repo owner). More details below.

During the development of these GH Actions changes, it became apparent the jobs can fire on many events. If the jobs fire too often we can add more conditional logic to tone down when/why they run.

_This has been reasonably tested in a test repo, but there's always a chance we may need to troubleshoot._
(Code and bugs are both free. :hand_over_mouth: :sweat_smile:)

```
GOAL:
- run test job on pushes to main branch or v* tag
- run test job on PRs against main branch
- run test job on Release creation
- if the the triggered actor is the repo owner ... run docker job on push/pull_request/release events
- run docker job on Release creation (ex: maybe a maintainer that isn't repo owner)
```

