### PR TITLE
Add missing footnote logic for more helpful error messages

### DIFF
--- a/fnsort.py
+++ b/fnsort.py
@@ -19,6 +19,10 @@ import argparse
 import re
 
 
+class MissingFootnoteError(Exception):
+    pass
+
+
 def parse_arguments():
     parser = argparse.ArgumentParser(description="Tidy Markdown footnotes")
     parser.add_argument(
@@ -100,7 +104,13 @@ def sort_footnotes(text):
 
     # Make a list of the footnote-references in order of appearance the original footnotes in text.
     # this is not the order of the footnote contents, but the order of the footnote references in the text.
-    newlabels = [f"[^{i+1}]: {labels[j]}" for (i, j) in enumerate(order)]
+    try:
+        newlabels = [f"[^{i+1}]: {labels[j]}" for (i, j) in enumerate(order)]
+    except KeyError as e:
+        # add custom exception to improve error output
+        raise MissingFootnoteError(
+            f"Missing footnote or inline reference = {repr(e)}"
+        )
     # print(f"newlabels: {newlabels}")
 
     # Remove the old footnote-references and put the new ones at the end of the text.

--- a/tests/missing/missing.md
+++ b/tests/missing/missing.md
@@ -1,0 +1,24 @@
+# HTTP Methods
+
+1. CONNECT[^c]
+1. DELETE[^d] - intentionally no footnote below
+1. GET [^g]
+1. HEAD [^h]
+1. OPTIONS[^o]
+1. PATCH[^pa]
+1. POST [^po]
+1. PUT [^pu]
+1. TRACE[^t]
+
+credit[^cr] where it's due, Thank you Mozilla
+
+[^t]: performs a message loop-back test along the path to the target resource
+[^o]: requests permitted communication options for a given URL or server
+[^g]: requests a representation of the specified resource
+[^c]: requests a proxy server establish a HTTP tunnel to a destination server
+[^cr]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
+[^oops]: ooops, did I add a footnote that doesn't exist in the inline text?
+[^pa]: applies partial modifications to a resource
+[^po]: sends data to the server
+[^pu]: creates a new resource or replaces a representation of the target resource with the request content
+[^h]: requests the metadata of a resource in the form of headers that the server would have sent if GET was used instead

--- a/tests/test_footnote_sorting.py
+++ b/tests/test_footnote_sorting.py
@@ -174,5 +174,35 @@ class TestAdjacentFootnotes(unittest.TestCase):
         self.assertEqual(fnsort.sort_footnotes(self.text), self.expected_text)
 
 
+class TestMissingFootnotes(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        path = "tests/missing"
+
+        with open(f"{path}/missing.md") as fh:
+            self.text = fh.read()
+
+        # missing footnotes or inline refs throw exceptions so there's no
+        #   sense in "expected" test file
+
+        # technically there is also a "file" kwarg by default
+        args = {"adjacent": False}
+        self.args = set_command_line_args(args)
+
+        # allow for full diff output
+        # self.maxDiff = None
+
+
+    def test_missing_footnotes(self):
+        """
+        [negative test] Entire footnote sort process with missing footnotes and inline references
+        """
+        if self.args.adjacent:
+            self.text = fnsort.space_adjacent_references(self.text)
+
+        with self.assertRaises(fnsort.MissingFootnoteError):
+            fnsort.sort_footnotes(self.text)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
When either inline references or footnotes are missing from the markdown, this causes a KeyError exception to be raised.

This KeyError exception can be vague so:
* a custom exception has been added
* test data and unit tests for this condition have also been added