### PR TITLE
Keep footnote and reference names

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -35,7 +35,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Run Python unit tests
-        run: python -m unittest discover -s ${{ env.test_dir }}
+        run: python -m unittest discover -v -s ${{ env.test_dir }}
 
   docker:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -38,5 +38,12 @@ This option adds spacing between those inline references so they are properly id
 
 `fnsort.py path/to/doc.md --adjacent`
 
+### --keepnames
+Retain or keep inline reference and footnote names.
+This prevents the default behavior of replacing the names with numbers.
+Footnotes at the end of the markdown are **still sorted**.
+
+`fnsort.py path/to/doc.md --keepnames`
+
 ## Contributing
 For information about contributing to this project, see the [contributing guidelines](CONTRIBUTING.md).

--- a/tests/keep_fn_names/keep_fn_names.md
+++ b/tests/keep_fn_names/keep_fn_names.md
@@ -1,0 +1,53 @@
+# Brown Bears
+
+Brown bears [^brn_bear] are majestic mammals best seen at a distance!
+There are several sub-species [^brn_bear] across Asia, Europe, and North America. Unfortunately mankind has endangered or pushed some species to extinction due to fur trade or human encroachment.
+
+![Grizzly Bear Sow and her cubs](https://upload.wikimedia.org/wikipedia/commons/thumb/d/d7/Grizzly_Bear-_Sow_and_cubs_%285728173840%29.jpg/320px-Grizzly_Bear-_Sow_and_cubs_%285728173840%29.jpg "Grizzly Bear Sow and her cubs")
+
+## Eurasian Brown Bear
+
+### Asia
+* East Siberian brown bear [^e_sib]
+* Gobi bear [^gobi]
+* Himalayan brown bear [^hima]
+* Kamchatkan brown bear [^kamch]
+* Syrian brown bear [^syr]
+* Tibetan brown bear [^tib]
+* Ussuri brown bear [^ussuri]
+
+### Europe
+* Cantabrian brown bear [^cant_bear]
+* Marsican brown bear [^mars_bear] - critically endangered
+
+## Grizzly Bear
+
+### North America
+* Californian grizzly bear[^cali] - extinct
+* Dall Island brown bear[^dall]
+* Kodiak bear [^kodiak]
+* Mexican grizzly bear[^mex] - extinct
+* Peninsular giant bear [^pgb]
+* Sitka brown bear[^sitka]
+* Stickeen brown bear[^stick]
+* Ungava brown bear[^ungava] - extinct
+
+
+[^kamch]:https://en.wikipedia.org/wiki/Kamchatka_brown_bear
+[^brn_bear]:https://en.wikipedia.org/wiki/Brown_bear
+[^tib]:https://en.wikipedia.org/wiki/Tibetan_blue_bear
+[^syr]:https://en.wikipedia.org/wiki/Syrian_brown_bear
+[^cant_bear]: https://en.wikipedia.org/wiki/Cantabrian_brown_bear
+[^e_sib]: https://en.wikipedia.org/wiki/East_Siberian_brown_bear
+[^hima]: https://en.wikipedia.org/wiki/Himalayan_brown_bear
+[^mars_bear]: https://en.wikipedia.org/wiki/Marsican_brown_bear
+[^gobi]: https://en.wikipedia.org/wiki/Gobi_bear
+[^ussuri]: https://en.wikipedia.org/wiki/Ussuri_brown_bear
+[^ungava]: https://en.wikipedia.org/wiki/Ungava_brown_bear
+[^stick]: https://en.wikipedia.org/wiki/Stickeen_brown_bear
+[^sitka]: https://en.wikipedia.org/wiki/ABC_Islands_bear
+[^pgb]: https://en.wikipedia.org/wiki/Alaska_Peninsula_brown_bear
+[^mex]: https://en.wikipedia.org/wiki/Mexican_grizzly_bear
+[^cali]: https://en.wikipedia.org/wiki/California_grizzly_bear
+[^kodiak]: https://en.wikipedia.org/wiki/Kodiak_bear
+[^dall]: https://en.wikipedia.org/wiki/Dall_Island

--- a/tests/keep_fn_names/keep_fn_names_expected.md
+++ b/tests/keep_fn_names/keep_fn_names_expected.md
@@ -32,21 +32,21 @@ There are several sub-species [^brn_bear] across Asia, Europe, and North America
 * Stickeen brown bear[^stick]
 * Ungava brown bear[^ungava] - extinct
 
-[^kamch]:https://en.wikipedia.org/wiki/Kamchatka_brown_bear
-[^brn_bear]:https://en.wikipedia.org/wiki/Brown_bear
-[^tib]:https://en.wikipedia.org/wiki/Tibetan_blue_bear
-[^syr]:https://en.wikipedia.org/wiki/Syrian_brown_bear
-[^cant_bear]: https://en.wikipedia.org/wiki/Cantabrian_brown_bear
+[^brn_bear]: https://en.wikipedia.org/wiki/Brown_bear
 [^e_sib]: https://en.wikipedia.org/wiki/East_Siberian_brown_bear
-[^hima]: https://en.wikipedia.org/wiki/Himalayan_brown_bear
-[^mars_bear]: https://en.wikipedia.org/wiki/Marsican_brown_bear
 [^gobi]: https://en.wikipedia.org/wiki/Gobi_bear
+[^hima]: https://en.wikipedia.org/wiki/Himalayan_brown_bear
+[^kamch]: https://en.wikipedia.org/wiki/Kamchatka_brown_bear
+[^syr]: https://en.wikipedia.org/wiki/Syrian_brown_bear
+[^tib]: https://en.wikipedia.org/wiki/Tibetan_blue_bear
 [^ussuri]: https://en.wikipedia.org/wiki/Ussuri_brown_bear
-[^ungava]: https://en.wikipedia.org/wiki/Ungava_brown_bear
-[^stick]: https://en.wikipedia.org/wiki/Stickeen_brown_bear
-[^sitka]: https://en.wikipedia.org/wiki/ABC_Islands_bear
-[^pgb]: https://en.wikipedia.org/wiki/Alaska_Peninsula_brown_bear
-[^mex]: https://en.wikipedia.org/wiki/Mexican_grizzly_bear
+[^cant_bear]: https://en.wikipedia.org/wiki/Cantabrian_brown_bear
+[^mars_bear]: https://en.wikipedia.org/wiki/Marsican_brown_bear
 [^cali]: https://en.wikipedia.org/wiki/California_grizzly_bear
-[^kodiak]: https://en.wikipedia.org/wiki/Kodiak_bear
 [^dall]: https://en.wikipedia.org/wiki/Dall_Island
+[^kodiak]: https://en.wikipedia.org/wiki/Kodiak_bear
+[^mex]: https://en.wikipedia.org/wiki/Mexican_grizzly_bear
+[^pgb]: https://en.wikipedia.org/wiki/Alaska_Peninsula_brown_bear
+[^sitka]: https://en.wikipedia.org/wiki/ABC_Islands_bear
+[^stick]: https://en.wikipedia.org/wiki/Stickeen_brown_bear
+[^ungava]: https://en.wikipedia.org/wiki/Ungava_brown_bear

--- a/tests/test_footnote_sorting.py
+++ b/tests/test_footnote_sorting.py
@@ -213,7 +213,7 @@ class TestMissingFootnotes(unittest.TestCase):
         #   sense in "expected" test file
 
         # technically there is also a "file" kwarg by default
-        args = {"adjacent": False}
+        args = {"adjacent": False, "keepnames": False}
         self.args = set_command_line_args(args)
 
         # allow for full diff output
@@ -228,7 +228,7 @@ class TestMissingFootnotes(unittest.TestCase):
             self.text = fnsort.space_adjacent_references(self.text)
 
         with self.assertRaises(fnsort.MissingFootnoteError):
-            fnsort.sort_footnotes(self.text)
+            fnsort.sort_footnotes(self.text, self.args)
 
 
 if __name__ == "__main__":

--- a/tests/test_footnote_sorting.py
+++ b/tests/test_footnote_sorting.py
@@ -24,7 +24,7 @@ class TestDefaults(unittest.TestCase):
             self.expected_text = fh.read()
 
         # technically there is also a "file" kwarg by default
-        args = {"adjacent": False}
+        args = {"adjacent": False, "keepnames": False}
         self.args = set_command_line_args(args)
         if self.args.adjacent:
             self.text = fnsort.space_adjacent_references(self.text)
@@ -50,7 +50,7 @@ class TestDefaults(unittest.TestCase):
 
     def test_footnote_sort(self):
         """ Entire footnote sort process """
-        self.assertEqual(fnsort.sort_footnotes(self.text), self.expected_text)
+        self.assertEqual(fnsort.sort_footnotes(self.text, self.args), self.expected_text)
 
 
 class TestDuplicates(unittest.TestCase):
@@ -65,7 +65,7 @@ class TestDuplicates(unittest.TestCase):
             self.expected_text = fh.read()
 
         # technically there is also a "file" kwarg by default
-        args = {"adjacent": False}
+        args = {"adjacent": False, "keepnames": False}
         self.args = set_command_line_args(args)
         if self.args.adjacent:
             self.text = fnsort.space_adjacent_references(self.text)
@@ -95,7 +95,7 @@ class TestDuplicates(unittest.TestCase):
 
     def test_footnote_sort_with_dups(self):
         """ Entire footnote sort process with duplicate tags """
-        self.assertEqual(fnsort.sort_footnotes(self.text), self.expected_text)
+        self.assertEqual(fnsort.sort_footnotes(self.text, self.args), self.expected_text)
 
 
 class TestFootnotesMustBeLast(unittest.TestCase):
@@ -110,7 +110,7 @@ class TestFootnotesMustBeLast(unittest.TestCase):
             self.expected_text = fh.read()
 
         # technically there is also a "file" kwarg by default
-        args = {"adjacent": False}
+        args = {"adjacent": False, "keepnames": False}
         self.args = set_command_line_args(args)
         if self.args.adjacent:
             self.text = fnsort.space_adjacent_references(self.text)
@@ -130,7 +130,7 @@ class TestFootnotesMustBeLast(unittest.TestCase):
 
         in short this is not expected to return the desired output
         """
-        self.assertNotEqual(fnsort.sort_footnotes(self.text), self.expected_text)
+        self.assertNotEqual(fnsort.sort_footnotes(self.text, self.args), self.expected_text)
 
 
 class TestAdjacentFootnotes(unittest.TestCase):
@@ -148,7 +148,7 @@ class TestAdjacentFootnotes(unittest.TestCase):
             self.expected_text = fh.read()
 
         # technically there is also a "file" kwarg by default
-        args = {"adjacent": True}
+        args = {"adjacent": True, "keepnames": False}
         self.args = set_command_line_args(args)
 
         # allow for full diff output
@@ -171,7 +171,34 @@ class TestAdjacentFootnotes(unittest.TestCase):
         if self.args.adjacent:
             self.text = fnsort.space_adjacent_references(self.text)
 
-        self.assertEqual(fnsort.sort_footnotes(self.text), self.expected_text)
+        self.assertEqual(fnsort.sort_footnotes(self.text, self.args), self.expected_text)
+
+
+class TestKeepFootnoteNames(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        path = "tests/keep_fn_names"
+
+        with open(f"{path}/keep_fn_names.md") as fh:
+            self.text = fh.read()
+
+        with open(f"{path}/keep_fn_names_expected.md") as fh:
+            self.expected_text = fh.read()
+
+        # technically there is also a "file" kwarg by default
+        args = {"adjacent": False, "keepnames": True}
+        self.args = set_command_line_args(args)
+
+        # allow for full diff output
+        # self.maxDiff = None
+
+
+    def test_keep_footnote_names(self):
+        """ Entire footnote sort process while retaining footnote names """
+        if self.args.adjacent:
+            self.text = fnsort.space_adjacent_references(self.text)
+
+        self.assertEqual(fnsort.sort_footnotes(self.text, self.args), self.expected_text)
 
 
 class TestMissingFootnotes(unittest.TestCase):


### PR DESCRIPTION
resolves #1 
feature enhancement

* Added `--keepnames` option
* Sorts the footnotes while retaining the reference and footnote names
  * This means footnotes and references are no longer replaced by numbers if `--keepnames` is passed
* (minor) Transitioned GitHub Actions unit test to run with the verbose option
  * This will allow GH Actions logging to have detailed workflow run output allowing for troubleshooting/identification right from Actions!
  * Such as the [output from this PR's testing](https://github.com/hellt/markdown-footnote-sorter/actions/runs/11131865329/job/30934423825?pr=14)!