### PR TITLE
Add Python linting and formatting checks

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -27,10 +27,16 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
-      - name: Run Ruff linting and formatting
+      - name: Run Ruff linter
         uses: astral-sh/ruff-action@v1
         with:
           args: "check"
+          changed-files: "true"
+
+      - name: Run Ruff formatter
+        uses: astral-sh/ruff-action@v1
+        with:
+          args: "format --check"
           changed-files: "true"
 
   test:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -11,8 +11,8 @@ on:
     types: ["created"]
 
 # GOAL:
-#  - run ruff linter/formatter job on pushes to main branch or v* tag
-#  - run ruff linter/formatter job on PRs against main branch
+#  - run ruff job on pushes to main branch or v* tag
+#  - run ruff job on PRs against main branch
 #  - run ruff job on Release creation
 #  - run test job on pushes to main branch or v* tag
 #  - run test job on PRs against main branch

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -11,6 +11,9 @@ on:
     types: ["created"]
 
 # GOAL:
+#  - run ruff linter/formatter job on pushes to main branch or v* tag
+#  - run ruff linter/formatter job on PRs against main branch
+#  - run ruff job on Release creation
 #  - run test job on pushes to main branch or v* tag
 #  - run test job on PRs against main branch
 #  - run test job on Release creation
@@ -18,8 +21,22 @@ on:
 #  - run docker job on Release creation (ex: maybe a maintainer that isn't repo owner)
 
 jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Run Ruff linting and formatting
+        uses: astral-sh/ruff-action@v1
+        with:
+          args: "check"
+          changed-files: "true"
+
   test:
     runs-on: ubuntu-latest
+    needs:
+      - "ruff"
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run Ruff formatter
         uses: astral-sh/ruff-action@v1
         with:
-          args: "format --check"
+          args: "format --check --diff"
           changed-files: "true"
 
   test:

--- a/fnsort.py
+++ b/fnsort.py
@@ -38,7 +38,7 @@ def parse_arguments():
         action="store_true",
         help="Fix adjacent footnotes by adding a space between them",
     )
-    
+
     parser.add_argument(
         "--keepnames",
         action="store_true",
@@ -87,7 +87,7 @@ def space_adjacent_references(text):
         # slice the string to separate preceding character from inline reference
         #   ex: s[^4]
         text = re.sub(note_re, f"{repl[0]} {repl[1:]}", text, flags=re.MULTILINE)
-    
+
     return text
 
 
@@ -120,9 +120,7 @@ def sort_footnotes(text, args):
             newlabels = [f"[^{i+1}]: {labels[j]}" for (i, j) in enumerate(order)]
     except KeyError as e:
         # add custom exception to improve error output
-        raise MissingFootnoteError(
-            f"Missing footnote or inline reference = {repr(e)}"
-        )
+        raise MissingFootnoteError(f"Missing footnote or inline reference = {repr(e)}")
 
     # print(f"newlabels: {newlabels}")
 

--- a/fnsort.py
+++ b/fnsort.py
@@ -86,7 +86,9 @@ def space_adjacent_references(text):
 
         # slice the string to separate preceding character from inline reference
         #   ex: s[^4]
-        text = re.sub(note_re, f"{repl[0]} {repl[1:]}", text, flags=re.MULTILINE)
+        text = re.sub(
+            note_re, f"{repl[0]} {repl[1:]}", text, flags=re.MULTILINE
+        )
 
     return text
 
@@ -117,10 +119,14 @@ def sort_footnotes(text, args):
         else:
             # Make a list of the footnote-references in order of appearance in the original footnotes in text.
             # This is not the order of the footnote contents, but the order of the footnote references in the text.
-            newlabels = [f"[^{i+1}]: {labels[j]}" for (i, j) in enumerate(order)]
+            newlabels = [
+                f"[^{i+1}]: {labels[j]}" for (i, j) in enumerate(order)
+            ]
     except KeyError as e:
         # add custom exception to improve error output
-        raise MissingFootnoteError(f"Missing footnote or inline reference = {repr(e)}")
+        raise MissingFootnoteError(
+            f"Missing footnote or inline reference = {repr(e)}"
+        )
 
     # print(f"newlabels: {newlabels}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.ruff]
+# Set the maximum line length to 79.
+line-length = 79

--- a/tests/test_footnote_sorting.py
+++ b/tests/test_footnote_sorting.py
@@ -77,11 +77,21 @@ class TestDuplicates(unittest.TestCase):
         order = ["1", "3", "2", "5", "4"]
 
         # should be seven regex matches in duplicates.md
-        expected = ["s[^1]", "s[^2]", " [^1]", "s[^3]", "s[^4]", "s[^5]", " [^2]"]
+        expected = [
+            "s[^1]",
+            "s[^2]",
+            " [^1]",
+            "s[^3]",
+            "s[^4]",
+            "s[^5]",
+            " [^2]",
+        ]
 
         # multiple assertions
         for i, match in enumerate(matches):
-            self.assertEqual(fnsort.replace_reference(match, order), expected[i])
+            self.assertEqual(
+                fnsort.replace_reference(match, order), expected[i]
+            )
 
     def test_footnote_sort_with_dups(self):
         """Entire footnote sort process with duplicate tags"""
@@ -152,7 +162,9 @@ class TestAdjacentFootnotes(unittest.TestCase):
         with open("tests/adjacent/adjacent_spacing.md") as fh:
             spacing_text = fh.read()
 
-        self.assertEqual(fnsort.space_adjacent_references(self.text), spacing_text)
+        self.assertEqual(
+            fnsort.space_adjacent_references(self.text), spacing_text
+        )
 
     def test_adjacent_footnote_sort(self):
         """Entire footnote sort process with adjacent footnote references"""

--- a/tests/test_footnote_sorting.py
+++ b/tests/test_footnote_sorting.py
@@ -149,7 +149,7 @@ class TestAdjacentFootnotes(unittest.TestCase):
 
     def test_adjacent_inline_reference_spacing(self):
         """Test spacing out adjacent inline references"""
-        with open(f"tests/adjacent/adjacent_spacing.md") as fh:
+        with open("tests/adjacent/adjacent_spacing.md") as fh:
             spacing_text = fh.read()
 
         self.assertEqual(fnsort.space_adjacent_references(self.text), spacing_text)

--- a/tests/test_footnote_sorting.py
+++ b/tests/test_footnote_sorting.py
@@ -5,7 +5,7 @@ import fnsort
 
 
 def set_command_line_args(args):
-    """ Set (what would otherwise be) command-line arguments """
+    """Set (what would otherwise be) command-line arguments"""
     return argparse.Namespace(**args)
 
 
@@ -32,25 +32,22 @@ class TestDefaults(unittest.TestCase):
         # allow for full diff output
         # self.maxDiff = None
 
-
     def test_replace_reference(self):
-        """ Inline reference replacement """
+        """Inline reference replacement"""
         # use the link regex from the fnsort import
-           
+
         # "search" function only returns the first match
         match = fnsort.link.search(self.text)
         order = ["1", "3", "4", "2"]
 
         # hedgehogs[^1]
-        self.assertEqual(
-            fnsort.replace_reference(match, order),
-            "s[^1]"
-        )
-
+        self.assertEqual(fnsort.replace_reference(match, order), "s[^1]")
 
     def test_footnote_sort(self):
-        """ Entire footnote sort process """
-        self.assertEqual(fnsort.sort_footnotes(self.text, self.args), self.expected_text)
+        """Entire footnote sort process"""
+        self.assertEqual(
+            fnsort.sort_footnotes(self.text, self.args), self.expected_text
+        )
 
 
 class TestDuplicates(unittest.TestCase):
@@ -73,29 +70,24 @@ class TestDuplicates(unittest.TestCase):
         # allow for full diff output
         # self.maxDiff = None
 
-
     def test_replace_references_with_dups(self):
-        """ Multiple reference replacements with duplicate tags """
+        """Multiple reference replacements with duplicate tags"""
         # find all matches
         matches = fnsort.link.finditer(self.text)
         order = ["1", "3", "2", "5", "4"]
 
         # should be seven regex matches in duplicates.md
-        expected = [
-            "s[^1]", "s[^2]", " [^1]", "s[^3]", "s[^4]", "s[^5]", " [^2]"
-        ]
+        expected = ["s[^1]", "s[^2]", " [^1]", "s[^3]", "s[^4]", "s[^5]", " [^2]"]
 
         # multiple assertions
         for i, match in enumerate(matches):
-            self.assertEqual(
-                fnsort.replace_reference(match, order),
-                expected[i]
-            )
-
+            self.assertEqual(fnsort.replace_reference(match, order), expected[i])
 
     def test_footnote_sort_with_dups(self):
-        """ Entire footnote sort process with duplicate tags """
-        self.assertEqual(fnsort.sort_footnotes(self.text, self.args), self.expected_text)
+        """Entire footnote sort process with duplicate tags"""
+        self.assertEqual(
+            fnsort.sort_footnotes(self.text, self.args), self.expected_text
+        )
 
 
 class TestFootnotesMustBeLast(unittest.TestCase):
@@ -118,9 +110,8 @@ class TestFootnotesMustBeLast(unittest.TestCase):
         # allow for full diff output
         # self.maxDiff = None
 
-
     def test_footnote_sort_trailing_text(self):
-        """ [negative test] Entire footnote sort process with text after the footnotes """
+        """[negative test] Entire footnote sort process with text after the footnotes"""
 
         """
         negative test
@@ -130,7 +121,9 @@ class TestFootnotesMustBeLast(unittest.TestCase):
 
         in short this is not expected to return the desired output
         """
-        self.assertNotEqual(fnsort.sort_footnotes(self.text, self.args), self.expected_text)
+        self.assertNotEqual(
+            fnsort.sort_footnotes(self.text, self.args), self.expected_text
+        )
 
 
 class TestAdjacentFootnotes(unittest.TestCase):
@@ -154,24 +147,21 @@ class TestAdjacentFootnotes(unittest.TestCase):
         # allow for full diff output
         # self.maxDiff = None
 
-
     def test_adjacent_inline_reference_spacing(self):
-        """ Test spacing out adjacent inline references """
+        """Test spacing out adjacent inline references"""
         with open(f"tests/adjacent/adjacent_spacing.md") as fh:
             spacing_text = fh.read()
 
-        self.assertEqual(
-            fnsort.space_adjacent_references(self.text),
-            spacing_text
-        )
-
+        self.assertEqual(fnsort.space_adjacent_references(self.text), spacing_text)
 
     def test_adjacent_footnote_sort(self):
-        """ Entire footnote sort process with adjacent footnote references """
+        """Entire footnote sort process with adjacent footnote references"""
         if self.args.adjacent:
             self.text = fnsort.space_adjacent_references(self.text)
 
-        self.assertEqual(fnsort.sort_footnotes(self.text, self.args), self.expected_text)
+        self.assertEqual(
+            fnsort.sort_footnotes(self.text, self.args), self.expected_text
+        )
 
 
 class TestKeepFootnoteNames(unittest.TestCase):
@@ -192,13 +182,14 @@ class TestKeepFootnoteNames(unittest.TestCase):
         # allow for full diff output
         # self.maxDiff = None
 
-
     def test_keep_footnote_names(self):
-        """ Entire footnote sort process while retaining footnote names """
+        """Entire footnote sort process while retaining footnote names"""
         if self.args.adjacent:
             self.text = fnsort.space_adjacent_references(self.text)
 
-        self.assertEqual(fnsort.sort_footnotes(self.text, self.args), self.expected_text)
+        self.assertEqual(
+            fnsort.sort_footnotes(self.text, self.args), self.expected_text
+        )
 
 
 class TestMissingFootnotes(unittest.TestCase):
@@ -218,7 +209,6 @@ class TestMissingFootnotes(unittest.TestCase):
 
         # allow for full diff output
         # self.maxDiff = None
-
 
     def test_missing_footnotes(self):
         """


### PR DESCRIPTION
Minor enhancement
Use `ruff` for Python linting and formatting

* Reformat code based on local findings from ruff
* Add GitHub Action job for ruff