### PR TITLE
Add Makefile for local testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,6 @@ cython_debug/
 
 # vim
 *.swp
+
+# Node.js
+node_modules/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,8 @@ For minimal dependencies, the "batteries included" [Python `unittest` framework]
 is utilized. (Other testing frameworks could be considered should additional
 testing features be needed.)
 
+Testing can be invoked via [`make test` (more information below)](#run-python-unit-tests)
+
 ## Development Process
 
 >
@@ -48,8 +50,11 @@ code regression.
 
 1. From the `main` branch of your fork, [create a feature branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository)
 
-1. Validate [test cases run successfully](#running-unit-tests) before any
+1. Validate [test cases run successfully](#run-python-unit-tests) before any
   changes are made
+
+1. Verify [linting and formatting checks run successfully](#run-all-linters-in-one-shot)
+  before making any changes
 
 1. Make modifications
 
@@ -59,12 +64,82 @@ code regression.
 
 1. Re-run the unit tests to confirm they run successfully
 
+1. Re-run linting and formatting checks
+
+1. Fix up any linting or formatting errors
+
 1. When you are satisfied with the changes and it is ready for review,
   [submit a Pull Request (PR)](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
 
-## Running Unit Tests
+## Using `make` to streamline linting and testing
 
-Choose one of the below testing commands methods that suits your needs.
+This project uses GNU `make` to simplify the action of interacting with several
+linters and performing unit testing.
+Project dependencies and Python virtual environment are managed with `uv`.
+
+## Prequisites:
+
+* [Install `uv` for package management](https://docs.astral.sh/uv/#getting-started)
+* Install GNU [`make`](https://www.gnu.org/software/make/) for your operating
+  system
+
+## General
+
+### Default (all)
+
+* initialize, lint, and test
+
+```bash
+make all
+
+# or simply
+make
+```
+
+### Clean
+
+* Remove caches created by Python, ruff, and npm
+
+`make clean`
+
+### Initialize
+
+* Create a Python virtual environment for ruff and yamlllint
+* Install Node.js markdownlint-cli2 package
+
+`make init`
+
+## Linting
+
+### Run all linters in one shot
+
+`make lint`
+
+### Run markdownlint-cli2 for Markdown linting
+
+`make mdlint`
+
+### Run ruff for Python linting
+
+`make ruff`
+
+### Run yamllint for Markdown linting
+
+`make yamllint`
+
+## Testing
+
+### Run Python unit tests
+
+`make test`
+
+## Running Unit Tests Manually
+
+> [!NOTE]
+> This information is somewhat historical since incorporating the Makefile,
+> but could prove useful.
+
+Choose one of the below testing command options that suits your needs.
 
 > [!IMPORTANT]
 > The commands below are to be run from the top level of the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ This project uses GNU `make` to simplify the action of interacting with several
 linters and performing unit testing.
 Project dependencies and Python virtual environment are managed with `uv`.
 
-## Prequisites:
+## Prequisites
 
 * [Install `uv` for package management](https://docs.astral.sh/uv/#getting-started)
 * Install GNU [`make`](https://www.gnu.org/software/make/) for your operating

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,9 +35,19 @@ testing features be needed.)
 
 Testing can be invoked via [`make test` (more information below)](#run-python-unit-tests)
 
+## Development Requirements
+
+* Python 3
+* GNU Make
+* Docker (Engine)
+
+> [!IMPORTANT]
+> If your development workstation has a security access control (ex: SELinux)
+> enabled, you will need to put it in a permissive mode for the Docker bind
+> mounts to function.
+
 ## Development Process
 
->
 > This section consists of suggestions.
 
 It is recommended to verify tests are successful before making any code changes.
@@ -79,15 +89,15 @@ Project dependencies and Python virtual environment are managed with `uv`.
 
 ## Prequisites
 
-* [Install `uv` for package management](https://docs.astral.sh/uv/#getting-started)
 * Install GNU [`make`](https://www.gnu.org/software/make/) for your operating
   system
+* Install Docker (Engine)
 
 ## General
 
 ### Default (all)
 
-* initialize, lint, and test
+* lint and test
 
 ```bash
 make all
@@ -98,16 +108,9 @@ make
 
 ### Clean
 
-* Remove caches created by Python, ruff, and npm
+* Removes the Docker images this Makefile utilizes
 
 `make clean`
-
-### Initialize
-
-* Create a Python virtual environment for ruff and yamlllint
-* Install Node.js markdownlint-cli2 package
-
-`make init`
 
 ## Linting
 
@@ -132,6 +135,29 @@ make
 ### Run Python unit tests
 
 `make test`
+
+## But I want to run linting locally
+
+> [!NOTE]
+> This project uses Docker images to avoid shipping or depending on other
+> projects, package managers, or languages (Node.js, Ruby).
+>
+> Non-Dockerized local testing is not supported by the repo owner.
+>
+> There are extra `make` targets in the Makefile in case you'd prefer local
+> linting and formatting.
+
+* Install GNU Make (same requirement as the main development pattern)
+* [Install `uv` for Python package management](https://docs.astral.sh/uv/#getting-started)
+* Install `npm` for Node.js package management
+
+```bash
+make localclean
+make localinit
+make localmdl
+make localruff
+make localyaml
+```
 
 ## Running Unit Tests Manually
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ all: lint test
 
 .PHONY: clean
 clean:
->   @docker rmi pipelinecomponents/ruff \
+>   @docker rmi ghcr.io/astral-sh/ruff:0.7.2 \
 >    davidanson/markdownlint-cli2:v0.14.0 \
 >    cytopia/yamllint
 
@@ -24,10 +24,10 @@ mdlint:
 # Python linting and formatting
 .PHONY: ruff
 ruff:
->   @docker run --rm -v ${PWD}:/workdir pipelinecomponents/ruff \
+>   @docker run --rm -v ${PWD}:/workdir ghcr.io/astral-sh/ruff:0.7.2 \
 >    check /workdir
->   @docker run --rm -v ${PWD}:/workdir pipelinecomponents/ruff \
->     format --check --diff /workdir
+>   @docker run --rm -v ${PWD}:/workdir ghcr.io/astral-sh/ruff:0.7.2 \
+>    format --check --diff /workdir
 
 # Python unit tests
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+.RECIPEPREFIX = >
 VENV ?= .venv/bin/activate
 
 all: init ruff mdlint yamllint test
@@ -5,17 +6,17 @@ all: init ruff mdlint yamllint test
 
 .PHONY: clean
 clean:
-	@rm -rf .venv node_modules .ruff_cache __pycache__ tests/__pycache__
+>   @rm -rf .venv node_modules .ruff_cache __pycache__ tests/__pycache__
 
 # set up the testing environment
 .PHONY: init
 .ONESHELL:
 init:
-	@uv venv
-	@source .venv/bin/activate
-	@uv pip install ruff yamllint
-	@deactivate
-	@npm install markdownlint-cli2 --save-dev
+>   @uv venv
+>   @source .venv/bin/activate
+>   @uv pip install ruff yamllint
+>   @deactivate
+>   @npm install markdownlint-cli2 --save-dev
 
 # run all the linting operations
 .PHONY: lint
@@ -24,23 +25,23 @@ lint: ruff mdlint yamllint
 # markdown linting
 .PHONY: mdlint
 mdlint:
-	@./node_modules/.bin/markdownlint-cli2 *.md tests/*/*.md
+>   @./node_modules/.bin/markdownlint-cli2 *.md tests/*/*.md
 
 # Python linting and formatting
 .PHONY: ruff
 ruff:
-	@source $(VENV)
-	@uv run ruff check
-	@uv run ruff format --check --diff
-	@deactivate
+>   @source $(VENV)
+>   @uv run ruff check
+>   @uv run ruff format --check --diff
+>   @deactivate
 
 .PHONY: test
 test:
-	@python -m unittest discover -s tests -v
+>   @python -m unittest discover -s tests -v
 
 # yaml linting
 .PHONY: yamllint
 yamllint:
-	@source $(VENV)
-	@uv run yamllint .
-	@deactivate
+>   @source $(VENV)
+>   @uv run yamllint .
+>   @deactivate

--- a/Makefile
+++ b/Makefile
@@ -1,40 +1,35 @@
 .RECIPEPREFIX = >
 VENV ?= .venv/bin/activate
 
-all: init ruff mdlint yamllint test
+all: lint test
 .PHONY: all
 
 .PHONY: clean
 clean:
->   @rm -rf .venv node_modules .ruff_cache __pycache__ tests/__pycache__
-
-# set up the testing environment
-.PHONY: init
-.ONESHELL:
-init:
->   @uv venv
->   @source .venv/bin/activate
->   @uv pip install ruff yamllint
->   @deactivate
->   @npm install markdownlint-cli2 --save-dev
+>   @docker rmi pipelinecomponents/ruff \
+>    davidanson/markdownlint-cli2:v0.14.0 \
+>    cytopia/yamllint
 
 # run all the linting operations
 .PHONY: lint
 lint: ruff mdlint yamllint
 
 # markdown linting
+# Note: Local security access control (ex: SELinux) will temporarily need to
+# 		be disabled for the Docker bind mounts to function.
 .PHONY: mdlint
 mdlint:
->   @./node_modules/.bin/markdownlint-cli2 *.md tests/*/*.md
+>   @docker run --rm -v ${PWD}:/workdir davidanson/markdownlint-cli2:v0.14.0
 
 # Python linting and formatting
 .PHONY: ruff
 ruff:
->   @source $(VENV)
->   @uv run ruff check
->   @uv run ruff format --check --diff
->   @deactivate
+>   @docker run --rm -v ${PWD}:/workdir pipelinecomponents/ruff \
+>    check /workdir
+>   @docker run --rm -v ${PWD}:/workdir pipelinecomponents/ruff \
+>     format --check --diff /workdir
 
+# Python unit tests
 .PHONY: test
 test:
 >   @python -m unittest discover -s tests -v
@@ -42,6 +37,44 @@ test:
 # yaml linting
 .PHONY: yamllint
 yamllint:
+>   @docker run --rm -v ${PWD}:/data cytopia/yamllint .
+
+
+### LOCAL DEVELOPMENT ###
+# (non-containerized)
+
+# clean up caches (ruff, node, py)
+.PHONY: localclean
+localclean:
+>   @rm -rf .venv node_modules .ruff_cache __pycache__ tests/__pycache__
+
+# set up the LOCAL testing environment
+.PHONY: localinit
+.ONESHELL:
+localinit:
+>   @uv venv
+>   @source .venv/bin/activate
+>   @uv pip install ruff yamllint
+>   @deactivate
+>   @npm install markdownlint-cli2 --save-dev
+
+# remains as an artifact for those who want to use local linting
+# LOCAL markdown linting
+.PHONY: localmdl
+localmdl:
+>   @./node_modules/.bin/markdownlint-cli2
+
+# LOCAL Python linting and formatting
+.PHONY: localruff
+localruff:
+>   @source $(VENV)
+>   @uv run ruff check
+>   @uv run ruff format --check --diff
+>   @deactivate
+
+# LOCAL yaml linting
+.PHONY: localyaml
+localyaml:
 >   @source $(VENV)
 >   @uv run yamllint .
 >   @deactivate

--- a/Makefile
+++ b/Makefile
@@ -5,17 +5,17 @@ all: init ruff mdlint yamllint test
 
 .PHONY: clean
 clean:
-	rm -rf .venv node_modules .ruff_cache __pycache__ tests/__pycache__
+	@rm -rf .venv node_modules .ruff_cache __pycache__ tests/__pycache__
 
 # set up the testing environment
 .PHONY: init
 .ONESHELL:
 init:
-	uv venv
-	source .venv/bin/activate
-	uv pip install ruff yamllint
-	deactivate
-	npm install markdownlint-cli2 --save-dev
+	@uv venv
+	@source .venv/bin/activate
+	@uv pip install ruff yamllint
+	@deactivate
+	@npm install markdownlint-cli2 --save-dev
 
 # run all the linting operations
 .PHONY: lint
@@ -24,23 +24,23 @@ lint: ruff mdlint yamllint
 # markdown linting
 .PHONY: mdlint
 mdlint:
-	./node_modules/.bin/markdownlint-cli2 *.md tests/*/*.md
+	@./node_modules/.bin/markdownlint-cli2 *.md tests/*/*.md
 
 # Python linting and formatting
 .PHONY: ruff
 ruff:
-	source $(VENV)
-	uv run ruff check
-	uv run ruff format --check --diff
-	deactivate
+	@source $(VENV)
+	@uv run ruff check
+	@uv run ruff format --check --diff
+	@deactivate
 
 .PHONY: test
 test:
-	python -m unittest discover -s tests -v
+	@python -m unittest discover -s tests -v
 
 # yaml linting
 .PHONY: yamllint
 yamllint:
-	source $(VENV)
-	uv run yamllint .
-	deactivate
+	@source $(VENV)
+	@uv run yamllint .
+	@deactivate

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+VENV ?= .venv/bin/activate
+
+all: init ruff mdlint yamllint test
+.PHONY: all
+
+.PHONY: clean
+clean:
+	rm -rf .venv node_modules .ruff_cache __pycache__ tests/__pycache__
+
+# set up the testing environment
+.PHONY: init
+.ONESHELL:
+init:
+	uv venv
+	source .venv/bin/activate
+	uv pip install ruff yamllint
+	deactivate
+	npm install markdownlint-cli2 --save-dev
+
+# run all the linting operations
+.PHONY: lint
+lint: ruff mdlint yamllint
+
+# markdown linting
+.PHONY: mdlint
+mdlint:
+	./node_modules/.bin/markdownlint-cli2 *.md tests/*/*.md
+
+# Python linting and formatting
+.PHONY: ruff
+ruff:
+	source $(VENV)
+	uv run ruff check
+	uv run ruff format --check --diff
+	deactivate
+
+.PHONY: test
+test:
+	python -m unittest discover -s tests -v
+
+# yaml linting
+.PHONY: yamllint
+yamllint:
+	source $(VENV)
+	uv run yamllint .
+	deactivate


### PR DESCRIPTION
resolves #17

What I believe to be the final piece to #17 for linting and formatting.

* Create a Makefile to cover linting and testing operations
  * Simply `make <TARGET>` and not have to worry about lengthy commands

There will be merge conflicts with other open PRs so I've left this one as a draft so that I can resolve the conflicts.