### PR TITLE
Replace Docker image and versions with variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,21 @@
 .RECIPEPREFIX = >
 VENV ?= .venv/bin/activate
 
+RUFF_IMG := ghcr.io/astral-sh/ruff
+RUFF_VER := 0.7.2
+MDLINT_IMG := davidanson/markdownlint-cli2
+MDLINT_VER := v0.14.0
+YAMLLINT_IMG := cytopia/yamllint
+YAMLLINT_VER := latest
+
 all: lint test
 .PHONY: all
 
 .PHONY: clean
 clean:
->   @docker rmi ghcr.io/astral-sh/ruff:0.7.2 \
->    davidanson/markdownlint-cli2:v0.14.0 \
->    cytopia/yamllint
+>   @docker rmi ${RUFF_IMG}:${RUFF_VER} \
+>    ${MDLINT_IMG}:${MDLINT_VER} \
+>    ${YAMLLINT_IMG}:${YAMLLINT_VER}
 
 # run all the linting operations
 .PHONY: lint
@@ -19,14 +26,14 @@ lint: ruff mdlint yamllint
 # 		be disabled for the Docker bind mounts to function.
 .PHONY: mdlint
 mdlint:
->   @docker run --rm -v ${PWD}:/workdir davidanson/markdownlint-cli2:v0.14.0
+>   @docker run --rm -v ${PWD}:/workdir ${MDLINT_IMG}:${MDLINT_VER}
 
 # Python linting and formatting
 .PHONY: ruff
 ruff:
->   @docker run --rm -v ${PWD}:/workdir ghcr.io/astral-sh/ruff:0.7.2 \
+>   @docker run --rm -v ${PWD}:/workdir ${RUFF_IMG}:${RUFF_VER} \
 >    check /workdir
->   @docker run --rm -v ${PWD}:/workdir ghcr.io/astral-sh/ruff:0.7.2 \
+>   @docker run --rm -v ${PWD}:/workdir ${RUFF_IMG}:${RUFF_VER} \
 >    format --check --diff /workdir
 
 # Python unit tests
@@ -37,7 +44,7 @@ test:
 # yaml linting
 .PHONY: yamllint
 yamllint:
->   @docker run --rm -v ${PWD}:/data cytopia/yamllint .
+>   @docker run --rm -v ${PWD}:/data ${YAMLLINT_IMG}:${YAMLLINT_VER} .
 
 
 ### LOCAL DEVELOPMENT ###


### PR DESCRIPTION
Use variables for Docker image names and versions to make version bumping much simpler in the future!
:rocket: